### PR TITLE
Add todo, project, and label management functionality

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,7 +16,10 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as http from "../http.js";
+import type * as labels from "../labels.js";
+import type * as projects from "../projects.js";
 import type * as sessions from "../sessions.js";
+import type * as todos from "../todos.js";
 import type * as users from "../users.js";
 import type * as utils from "../utils.js";
 
@@ -30,7 +33,10 @@ import type * as utils from "../utils.js";
  */
 declare const fullApi: ApiFromModules<{
   http: typeof http;
+  labels: typeof labels;
+  projects: typeof projects;
   sessions: typeof sessions;
+  todos: typeof todos;
   users: typeof users;
   utils: typeof utils;
 }>;

--- a/convex/labels.ts
+++ b/convex/labels.ts
@@ -1,0 +1,96 @@
+import { mutateWithUser, queryWithUser } from "./utils";
+import { internalQuery } from "./_generated/server";
+import { Labels } from "./schema";
+
+// LABELS QUERIES
+export const getOneByUser = queryWithUser({
+  args: { labelId: Labels._id },
+  handler: ({ db, identity }, { labelId }) => {
+    const userId = identity.tokenIdentifier;
+    return db
+      .query("labels")
+      .filter((q) =>
+        q.and(q.eq(q.field("_id"), labelId), q.eq(q.field("userId"), userId))
+      )
+      .unique();
+  },
+});
+
+export const getAllByUser = queryWithUser({
+  args: {},
+  handler: async ({ db, identity }) => {
+    const user = identity.tokenIdentifier;
+
+    return db
+      .query("labels")
+      .filter((q) => q.eq(q.field("userId"), user))
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getOne = internalQuery({
+  args: { labelId: Labels._id },
+  handler: async ({ db }, { labelId }) => {
+    return await db.get(labelId);
+  },
+});
+
+export const getAll = internalQuery({
+  args: {},
+  handler: ({ db }) => {
+    return db.query("labels").order("desc").collect();
+  },
+});
+
+// LABELS MUTATIONS
+export const create = mutateWithUser({
+  args: Labels.withoutSystemFields,
+  handler: async ({ db, identity }, { name, ...rest }) => {
+    const userId = identity.tokenIdentifier;
+
+    const label = await db
+      .query("labels")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("name"), name))
+      .unique();
+
+    if (label) throw new Error("Label already exists");
+
+    return db.insert("labels", { ...rest, userId, name });
+  },
+});
+
+export const update = mutateWithUser({
+  args: Labels.withSystemFields,
+  handler: async ({ db, identity }, { _id, name }) => {
+    const userId = identity.tokenIdentifier;
+
+    const label = await db
+      .query("labels")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), _id))
+      .unique();
+
+    if (!label) return null;
+
+    return await db.patch(label._id, { name });
+  },
+});
+
+export const remove = mutateWithUser({
+  args: { labelId: Labels._id },
+  handler: async ({ db, identity }, { labelId }) => {
+    const userId = identity.tokenIdentifier;
+
+    const label = await db
+      .query("labels")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), labelId))
+      .unique();
+
+    if (!label) throw new Error("Label does not exist.");
+
+    return await db.delete(label._id);
+  },
+});

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,0 +1,92 @@
+import { mutateWithUser, queryWithUser } from "./utils";
+import { internalQuery } from "./_generated/server";
+import { Projects } from "./schema";
+import { paginationOptsValidator } from "convex/server";
+
+// PROJECT QUERIES
+export const getOneByUser = queryWithUser({
+  args: { projectId: Projects._id },
+  handler: (ctx, { projectId }) => {
+    const userId = ctx.identity.tokenIdentifier;
+    return ctx.db
+      .query("projects")
+      .filter((q) =>
+        q.and(q.eq(q.field("_id"), projectId), q.eq(q.field("userId"), userId))
+      )
+      .unique();
+  },
+});
+
+export const getAllByUser = queryWithUser({
+  args: {},
+  handler: async (ctx) => {
+    const user = ctx.identity.tokenIdentifier;
+    return ctx.db
+      .query("projects")
+      .filter((q) => q.eq(q.field("userId"), user))
+      .order("desc")
+      .collect();
+  },
+});
+
+export const getOne = internalQuery({
+  args: { projectId: Projects._id },
+  handler: async (ctx, { projectId }) => {
+    return await ctx.db.get(projectId);
+  },
+});
+
+export const getAll = internalQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: (ctx, { paginationOpts }) => {
+    return ctx.db.query("projects").order("desc").paginate(paginationOpts);
+  },
+});
+
+// PROJECT MUTATIONS
+export const create = mutateWithUser({
+  args: Projects.withoutSystemFields,
+  handler: async (ctx, { name, ...rest }) => {
+    const userId = ctx.identity.tokenIdentifier;
+
+    const project = await ctx.db
+      .query("projects")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("name"), name))
+      .unique();
+
+    if (project) throw new Error("Project already exists");
+
+    return ctx.db.insert("projects", { ...rest, userId, name });
+  },
+});
+
+export const update = mutateWithUser({
+  args: Projects.withSystemFields,
+  handler: async ({ db, identity }, { _id, name }) => {
+    const project = await db
+      .query("projects")
+      .withIndex("by_user", (q) => q.eq("userId", identity.tokenIdentifier))
+      .filter((q) => q.eq(q.field("_id"), _id))
+      .unique();
+    if (!project) return null;
+    const updated = await db.patch(project._id, { name });
+    return updated;
+  },
+});
+
+export const remove = mutateWithUser({
+  args: { projectId: Projects._id },
+  handler: async ({ db, identity }, { projectId }) => {
+    const userId = identity.tokenIdentifier;
+    const project = await db
+      .query("projects")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), projectId))
+      .unique();
+
+    if (!project) throw new Error("Project does not exist.");
+
+    return db.delete(project._id);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -23,10 +23,53 @@ export const Sessions = Table("sessions", {
   lastActiveAt: v.number(),
 });
 
+export const Todos = Table("todos", {
+  title: v.string(),
+  description: v.optional(v.string()),
+  userId: v.string(),
+  projectId: v.id("projects"),
+  labelId: v.id("labels"),
+  priority: v.optional(v.float64()),
+  isCompleted: v.boolean(),
+  dueDate: v.number(),
+});
+
+export const SubTasks = Table("subtasks", {
+  title: v.string(),
+  description: v.optional(v.string()),
+  userId: v.string(),
+  todoId: v.id("todos"),
+  priority: v.optional(v.float64()),
+  isCompleted: v.boolean(),
+  dueDate: v.number(),
+});
+
+export const Labels = Table("labels", {
+  name: v.string(),
+  userId: v.string(),
+  type: v.union(v.literal("system"), v.literal("user")),
+});
+
+export const Projects = Table("projects", {
+  name: v.string(),
+  userId: v.string(),
+  type: v.union(v.literal("system"), v.literal("user")),
+});
+
 export default defineSchema({
   users: Users.table.index("by_token", ["tokenIdentifier"]),
   sessions: Sessions.table
     .index("by_user", ["userId"])
     .index("by_status", ["status"])
     .index("by_sess_id", ["sessionId"]),
+  todos: Todos.table
+    .index("by_title", ["title"])
+    .index("by_user", ["userId"])
+    .index("by_label", ["labelId"])
+    .index("by_project", ["projectId"]),
+  subtasks: SubTasks.table
+    .index("by_user", ["userId"])
+    .index("by_todo", ["todoId"]),
+  labels: Labels.table.index("by_user", ["userId"]),
+  projects: Projects.table.index("by_user", ["userId"]),
 });

--- a/convex/todos.ts
+++ b/convex/todos.ts
@@ -1,0 +1,210 @@
+import { mutateWithUser, queryWithUser } from "./utils";
+import { internalQuery } from "./_generated/server";
+import { Todos, SubTasks } from "./schema";
+
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+
+// QUERIES
+export const getOneByUser = queryWithUser({
+  args: { todoId: Todos._id, includeSubTasks: v.optional(v.boolean()) },
+  handler: async (ctx, { todoId, includeSubTasks }) => {
+    const userId = ctx.identity.tokenIdentifier;
+
+    const todo = await ctx.db
+      .query("todos")
+      .filter((q) =>
+        q.and(q.eq(q.field("_id"), todoId), q.eq(q.field("userId"), userId))
+      )
+      .unique();
+
+    if (!todo) return null;
+
+    if (!includeSubTasks) return todo;
+
+    const subTasks = await ctx.db
+      .query("subtasks")
+      .withIndex("by_todo", (q) => q.eq("todoId", todo._id))
+      .collect();
+
+    return { ...todo, subTasks };
+  },
+});
+
+export const getAllByUser = queryWithUser({
+  args: { includeSubTasks: v.optional(v.boolean()) },
+  handler: async (ctx, { includeSubTasks }) => {
+    const user = ctx.identity.tokenIdentifier;
+    const todos = await ctx.db
+      .query("todos")
+      .filter((q) => q.eq(q.field("userId"), user))
+      .order("desc")
+      .collect();
+
+    if (!includeSubTasks) return todos;
+
+    const payload = [];
+
+    for (const todo of todos) {
+      const subTask = await ctx.db
+        .query("subtasks")
+        .withIndex("by_todo", (q) => q.eq("todoId", todo._id))
+        .order("desc")
+        .collect();
+      const group = { ...todo, subTask };
+      payload.push(group);
+    }
+
+    return payload;
+  },
+});
+
+export const getOne = internalQuery({
+  args: { todoId: Todos._id },
+  handler: async (ctx, { todoId }) => {
+    return await ctx.db.get(todoId);
+  },
+});
+
+export const getAll = internalQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: (ctx, { paginationOpts }) => {
+    return ctx.db.query("todos").order("desc").paginate(paginationOpts);
+  },
+});
+
+// MUTATIONS
+export const create = mutateWithUser({
+  args: Todos.withoutSystemFields,
+  handler: async (ctx, { title, projectId, ...rest }) => {
+    const userId = ctx.identity.tokenIdentifier;
+
+    const project = await ctx.db
+      .query("projects")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), projectId))
+      .unique();
+
+    if (!project) throw new Error("Project does not exist");
+
+    const todo = await ctx.db
+      .query("todos")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("title"), title))
+      .unique();
+
+    if (todo) throw new Error("Todo already exists");
+
+    return ctx.db.insert("todos", { ...rest, userId, title, projectId });
+  },
+});
+
+export const createSubTask = mutateWithUser({
+  args: SubTasks.withoutSystemFields,
+  handler: async ({ db, identity }, { todoId, ...rest }) => {
+    const userId = identity.tokenIdentifier;
+
+    const todo = await db
+      .query("todos")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), todoId))
+      .unique();
+
+    if (!todo) throw new Error("Todo does not exist");
+
+    const payload = { ...rest, userId, todoId };
+
+    return db.insert("subtasks", payload);
+  },
+});
+
+export const update = mutateWithUser({
+  args: Todos.withSystemFields,
+  handler: async ({ db, identity }, { _id, projectId, labelId, ...rest }) => {
+    const userId = identity.tokenIdentifier;
+
+    const todo = await db
+      .query("todos")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), _id))
+      .unique();
+
+    if (!todo) return null;
+
+    const { title, priority, isCompleted, description, dueDate } = rest;
+
+    await db.patch(todo._id, {
+      description,
+      priority,
+      title,
+      isCompleted,
+      dueDate,
+      projectId,
+      labelId,
+    });
+  },
+});
+
+export const updateSubTask = mutateWithUser({
+  args: SubTasks.withSystemFields,
+  handler: async ({ db, identity }, { _id, description, dueDate, ...rest }) => {
+    const userId = identity.tokenIdentifier;
+
+    const subTask = await db
+      .query("subtasks")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), _id))
+      .unique();
+
+    if (!subTask) throw new Error("SubTask does not exist!");
+
+    const { title, priority, isCompleted } = rest;
+
+    const payload = { description, dueDate, priority, title, isCompleted };
+
+    await db.patch(subTask._id, payload);
+  },
+});
+
+export const remove = mutateWithUser({
+  args: { todoId: Todos._id },
+  handler: async ({ db, identity }, { todoId }) => {
+    const userId = identity.tokenIdentifier;
+
+    const todo = await db
+      .query("todos")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), todoId))
+      .unique();
+
+    if (!todo) throw new Error("Todo does not exist.");
+
+    await db
+      .query("subtasks")
+      .withIndex("by_todo", (q) => q.eq("todoId", todo._id))
+      .order("desc")
+      .collect()
+      .then((subTasks) =>
+        subTasks.forEach(async (task) => await db.delete(task._id))
+      );
+
+    return db.delete(todo._id);
+  },
+});
+
+export const deleteSubTask = mutateWithUser({
+  args: { subTaskId: SubTasks._id },
+  handler: async ({ db, identity }, { subTaskId }) => {
+    const userId = identity.tokenIdentifier;
+
+    const subTask = await db
+      .query("subtasks")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("_id"), subTaskId))
+      .unique();
+
+    if (!subTask) throw new Error("SubTask does not exist!");
+
+    return db.delete(subTask._id);
+  },
+});

--- a/convex/utils.ts
+++ b/convex/utils.ts
@@ -8,12 +8,13 @@ import {
   customQuery,
   customCtx,
 } from "convex-helpers/server/customFunctions";
+
 import {
   type ActionCtx,
+  type QueryCtx,
   action,
   mutation,
   query,
-  type QueryCtx,
 } from "./_generated/server";
 
 type CustomCtxType = ActionCtx | QueryCtx;


### PR DESCRIPTION
### TL;DR
Added core functionality for managing todos, projects, and labels with their respective CRUD operations.

### What changed?
- Implemented todo management with support for subtasks
- Added project management capabilities
- Created label management system
- Updated schema to include new tables for todos, subtasks, labels, and projects
- Added appropriate indexes for efficient querying
- Implemented user-specific queries and mutations for data security

### How to test?
1. Create a new project using `projects.create`
2. Create a label using `labels.create`
3. Create a todo with `todos.create` and assign it to the project
4. Add subtasks to the todo using `todos.createSubTask`
5. Verify CRUD operations:
   - Update todo details
   - Mark todos/subtasks as complete
   - Delete todos and verify cascade deletion of subtasks
   - Modify project and label information

### Why make this change?
To establish the foundational data structure and API endpoints necessary for a task management system, enabling users to organize their work through projects, apply labels for categorization, and break down tasks into manageable subtasks.