### PR TITLE
Add today's todos view and due date indicators

### DIFF
--- a/convex/todos.ts
+++ b/convex/todos.ts
@@ -65,6 +65,26 @@ export const getRecentTodos = queryWithUser({
   },
 });
 
+export const getTodayTodos = queryWithUser({
+  handler: async ({ db, identity }) => {
+    const userId = identity.tokenIdentifier;
+
+    const todos = await db
+      .query("todos")
+      .filter((q) => q.eq(q.field("userId"), userId))
+      .order("desc")
+      .collect();
+
+    const todayTodos = todos.filter(({ dueDate }) => {
+      const today = new Date();
+      const diffInHours = differenceInHours(new Date(dueDate!), today);
+      return diffInHours <= 24 && diffInHours >= 0;
+    });
+
+    return todayTodos;
+  },
+});
+
 export const getAllByUser = queryWithUser({
   args: { includeSubTasks: v.optional(v.boolean()) },
   handler: async (ctx, { includeSubTasks }) => {

--- a/src/app/dashboard/today/todos.tsx
+++ b/src/app/dashboard/today/todos.tsx
@@ -6,7 +6,7 @@ import { api } from "@/convex/_generated/api";
 import { useQuery } from "convex/react";
 
 export const TodayTodos = () => {
-  const todos = useQuery(api.todos.getRecentTodos, { duration: "24 hours" });
+  const todos = useQuery(api.todos.getTodayTodos);
 
   if (todos === undefined) {
     return (

--- a/src/components/todos/todo-item.tsx
+++ b/src/components/todos/todo-item.tsx
@@ -1,6 +1,10 @@
 import type { Id } from "@/convex/_generated/dataModel";
 import type { TodoItem } from "@/types";
 
+import { differenceInMinutes } from "date-fns/differenceInMinutes";
+import { intlFormatDistance } from "date-fns/intlFormatDistance";
+import { differenceInHours } from "date-fns/differenceInHours";
+import { AlarmClock, RefreshCw } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Text } from "@/components/ui/typography";
 import { Label } from "@/components/ui/label";
@@ -12,14 +16,26 @@ export interface TodoItemProps {
 }
 
 export function TodoItem({ todo, handleToggle }: TodoItemProps) {
-  const { _id, title, isCompleted } = todo;
+  const { _id, title, isCompleted, dueDate } = todo;
+
+  const current = new Date();
+
+  const diffInHrs = differenceInHours(dueDate!, current);
+  const within2Hr = diffInHrs <= 2 && diffInHrs >= 1;
+
+  const diffInMins = differenceInMinutes(dueDate!, current);
+  const within1Hr = diffInMins <= 59 && diffInMins >= 1;
+
+  const pastDueDate = diffInHrs <= 0 && diffInMins <= 0;
 
   const checkId = `todo-${_id}`;
 
   return (
-    <div className="flex flex-col py-1.5 border-b border-zinc-100 dark:border-zinc-800">
+    <div className="flex flex-col py-1.5 pb-2 gap-2 border-b border-zinc-100 dark:border-zinc-800">
       <div
-        className={cn("flex items-center gap-2", { "opacity-50": isCompleted })}
+        className={cn("flex items-center gap-2", {
+          "opacity-50 [&_p]:font-normal": isCompleted,
+        })}
       >
         <Label
           htmlFor={checkId}
@@ -34,10 +50,33 @@ export function TodoItem({ todo, handleToggle }: TodoItemProps) {
             className={cn("rounded-full size-4")}
             onCheckedChange={() => handleToggle(_id, !isCompleted)}
           />
-          <Text className="[&:not(:first-child)]:mt-0">{title}</Text>
+          <Text className="[&:not(:first-child)]:mt-0 font-medium leading-4">
+            {title}
+          </Text>
         </Label>
       </div>
-      <div></div>
+      {!isCompleted && (
+        <div className="flex flex-1 ml-6">
+          <Text
+            className={cn(
+              "text-foreground/50 text-xs font-normal leading-none flex gap-1",
+              {
+                "text-yellow-400": within2Hr,
+                "text-orange-400": within1Hr,
+                "text-destructive dark:text-red-500": pastDueDate,
+              }
+            )}
+          >
+            {pastDueDate && (
+              <RefreshCw className="size-3 text-red-400 cursor-pointer hover:text-red-500 stroke-[2.5px]" />
+            )}
+            {intlFormatDistance(dueDate!, current)}
+            {(within2Hr || within1Hr) && (
+              <AlarmClock className="size-3 cursor-pointer stroke-[2.5px]" />
+            )}
+          </Text>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/todos/todo-list.tsx
+++ b/src/components/todos/todo-list.tsx
@@ -51,7 +51,7 @@ export function Todolist({ todos }: TodolistProps) {
 
         <CreateTodo>
           <Button
-            className="self-start px-0 hover:bg-transparent"
+            className="self-start px-0 hover:bg-transparent my-1"
             variant="ghost"
           >
             <Plus className="mr-1.5 stroke-red-400 stroke-[1px] size-5" />


### PR DESCRIPTION
### TL;DR
Added due date indicators and a new query for today's todos

### What changed?
- Created a new `getTodayTodos` query to fetch todos due within 24 hours
- Added visual indicators for todos based on their due date:
  - Yellow warning for tasks due within 2 hours
  - Orange warning for tasks due within 1 hour
  - Red indicator for overdue tasks
- Enhanced todo item styling with relative time display
- Added refresh and alarm clock icons for overdue and urgent tasks

### How to test?
1. Create todos with different due dates
2. Verify color indicators:
   - Tasks due in 2 hours show yellow warning
   - Tasks due in 1 hour show orange warning
   - Overdue tasks show red warning
3. Check that completed tasks hide the due date indicators
4. Confirm the refresh icon appears for overdue tasks
5. Verify the alarm clock icon shows for urgent tasks

### Why make this change?
To improve task urgency awareness by providing visual feedback about upcoming and overdue tasks, helping users better manage their time and priorities.