### PR TITLE
Update date handling and locale settings for todos

### DIFF
--- a/convex/todos.ts
+++ b/convex/todos.ts
@@ -1,15 +1,16 @@
 import { differenceInHours } from "date-fns/differenceInHours";
+import { setDefaultOptions } from "date-fns/setDefaultOptions";
 import { paginationOptsValidator } from "convex/server";
+import { isSameDay } from "date-fns/isSameDay";
+import { enGB } from "date-fns/locale";
 import { pick, pickBy } from "lodash";
 import { v } from "convex/values";
 
+import { sanitizeInput, mutateWithUser, queryWithUser } from "./utils";
 import { internalQuery } from "./_generated/server";
 import { Todos, SubTasks } from "./schema";
-import {
-  sanitizeInput as sanitize,
-  mutateWithUser,
-  queryWithUser,
-} from "./utils";
+
+setDefaultOptions({ locale: enGB });
 
 // QUERIES
 export const getOneByUser = queryWithUser({
@@ -75,13 +76,9 @@ export const getTodayTodos = queryWithUser({
       .order("desc")
       .collect();
 
-    const todayTodos = todos.filter(({ dueDate }) => {
-      const today = new Date();
-      const diffInHours = differenceInHours(new Date(dueDate!), today);
-      return diffInHours <= 24 && diffInHours >= 0;
-    });
-
-    return todayTodos;
+    return todos.filter(({ dueDate }) =>
+      isSameDay(new Date(), new Date(dueDate!))
+    );
   },
 });
 
@@ -153,7 +150,7 @@ export const create = mutateWithUser({
       if (!project) throw new Error("Project does not exist");
     }
 
-    const input = sanitize(rest, [
+    const input = sanitizeInput(rest, [
       "description",
       "projectId",
       "priority",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,11 @@ import type { PropsWithChildren } from "react";
 import type { Metadata } from "next";
 
 import { ConvexClientProvider } from "@/components/convex-client-provider";
+import { setDefaultOptions } from "date-fns/setDefaultOptions";
 import { ThemeProvider } from "@/components/theme-provider";
 import { geistMono, geistSans } from "@/lib/fonts";
 import { ClerkProvider } from "@clerk/nextjs";
+import { enGB } from "date-fns/locale";
 import { Toaster } from "sonner";
 import { env } from "env.mjs";
 
@@ -16,6 +18,8 @@ export const metadata: Metadata = {
 };
 
 const publishableKey = env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY! as string;
+
+setDefaultOptions({ locale: enGB });
 
 export default function RootLayout({ children }: Readonly<PropsWithChildren>) {
   return (

--- a/src/components/todos/form.tsx
+++ b/src/components/todos/form.tsx
@@ -8,9 +8,9 @@ import { DialogFooter } from "@/components/ui/dialog";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
+import { addMinutes } from "date-fns/addMinutes";
 import { Button } from "@/components/ui/button";
 import { useForm } from "react-hook-form";
-import { addHours } from "date-fns";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { z } from "zod";
@@ -59,7 +59,7 @@ export function CreateTodosForm(props: CreateTodosFormProps) {
     labels,
     projects,
     isCompleted: false,
-    dueDate: addHours(Date.now(), 24),
+    dueDate: addMinutes(new Date(), 30),
   };
 
   const [show, setShow] = useState(false);

--- a/src/components/todos/todo-item.tsx
+++ b/src/components/todos/todo-item.tsx
@@ -19,11 +19,12 @@ export function TodoItem({ todo, handleToggle }: TodoItemProps) {
   const { _id, title, isCompleted, dueDate } = todo;
 
   const current = new Date();
+  const formatedDueDate = new Date(dueDate!);
 
-  const diffInHrs = differenceInHours(dueDate!, current);
+  const diffInHrs = differenceInHours(formatedDueDate, current);
   const within2Hr = diffInHrs <= 2 && diffInHrs >= 1;
 
-  const diffInMins = differenceInMinutes(dueDate!, current);
+  const diffInMins = differenceInMinutes(formatedDueDate, current);
   const within1Hr = diffInMins <= 59 && diffInMins >= 1;
 
   const pastDueDate = diffInHrs <= 0 && diffInMins <= 0;
@@ -47,7 +48,7 @@ export function TodoItem({ todo, handleToggle }: TodoItemProps) {
           <Checkbox
             id={checkId}
             checked={isCompleted}
-            className={cn("rounded-full size-4")}
+            className={cn("rounded-full size-4 text-muted")}
             onCheckedChange={() => handleToggle(_id, !isCompleted)}
           />
           <Text className="[&:not(:first-child)]:mt-0 font-medium leading-4">
@@ -70,7 +71,7 @@ export function TodoItem({ todo, handleToggle }: TodoItemProps) {
             {pastDueDate && (
               <RefreshCw className="size-3 text-red-400 cursor-pointer hover:text-red-500 stroke-[2.5px]" />
             )}
-            {intlFormatDistance(dueDate!, current)}
+            {intlFormatDistance(formatedDueDate, current)}
             {(within2Hr || within1Hr) && (
               <AlarmClock className="size-3 cursor-pointer stroke-[2.5px]" />
             )}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,7 +48,7 @@ export const getDateTimeLocal = (timestamp?: Date): string => {
  * @returns A string representation of the date and time
  */
 export const formatDateTime = (datetime: Date | string) => {
-  return new Date(datetime).toLocaleTimeString("en-US", {
+  return new Date(datetime).toLocaleTimeString("en-GB", {
     month: "short",
     day: "numeric",
     year: "numeric",


### PR DESCRIPTION
### TL;DR
Standardized date handling across the application by implementing British English (en-GB) locale and improving due date calculations for todos.

### What changed?
- Set British English (en-GB) as the default locale for date-fns
- Replaced manual hour calculations with `isSameDay` for today's todos
- Changed default todo due date from 24 hours to 30 minutes
- Updated datetime formatting to use British English format
- Fixed date comparison logic in todo items by properly instantiating Date objects
- Enhanced checkbox styling with muted text color

### How to test?
1. Create a new todo and verify the default due date is set to 30 minutes from now
2. Check that all date displays use British English format (DD/MM/YYYY)
3. Verify that "Today's todos" correctly shows items due on the current calendar day
4. Confirm that due date warnings (within 1hr, 2hrs, overdue) display accurately

### Why make this change?
To provide consistent date handling and improve the accuracy of todo due dates across the application. The previous implementation had inconsistencies in date calculations and locale formatting, which could lead to confusion for users.