### PR TITLE
Add project creation functionality and UI components

### DIFF
--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -46,8 +46,8 @@ export const getAll = internalQuery({
 
 // PROJECT MUTATIONS
 export const create = mutateWithUser({
-  args: Projects.withoutSystemFields,
-  handler: async (ctx, { name, ...rest }) => {
+  args: { name: Projects.doc.fields.name },
+  handler: async (ctx, { name }) => {
     const userId = ctx.identity.tokenIdentifier;
 
     const project = await ctx.db
@@ -58,7 +58,7 @@ export const create = mutateWithUser({
 
     if (project) throw new Error("Project already exists");
 
-    return ctx.db.insert("projects", { ...rest, userId, name });
+    return ctx.db.insert("projects", { type: "user", userId, name });
   },
 });
 

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 
 import { MoreHorizontal, Trash2, Folder, Share, Frame } from "lucide-react";
+import { CreateProject } from "@/components/projects/create-new";
 import { api } from "@/convex/_generated/api";
 import { useQuery } from "convex/react";
 
@@ -31,7 +32,10 @@ export function NavProjects() {
 
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-      <SidebarGroupLabel>Projects</SidebarGroupLabel>
+      <SidebarGroupLabel className="justify-between">
+        Projects
+        <CreateProject />
+      </SidebarGroupLabel>
       <SidebarMenu>
         {projects === undefined ? (
           Array.from({ length: 3 }).map((_, index) => (

--- a/src/components/projects/create-new.tsx
+++ b/src/components/projects/create-new.tsx
@@ -1,0 +1,50 @@
+import { type Schema, CreateProjectForm } from "@/components/projects/form";
+
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { useMutation } from "convex/react";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+  PopoverTrigger,
+  PopoverContent,
+  Popover,
+} from "@/components/ui/popover";
+
+export type FormStateType = "idle" | "loading" | "success";
+
+export function CreateProject() {
+  const createProject = useMutation(api.projects.create);
+
+  const [formState, setFormState] = useState<FormStateType>("idle");
+  const [isOpen, setOpen] = useState(false);
+
+  function submit({ title }: Schema) {
+    setFormState("loading");
+
+    toast.promise(createProject({ name: title }), {
+      success: "Project created successfully",
+      error: "Failed to create project",
+      loading: "Creating project...",
+      finally() {
+        setOpen(false);
+        setFormState("idle");
+      },
+    });
+  }
+
+  return (
+    <Popover open={isOpen} onOpenChange={setOpen}>
+      <PopoverTrigger title="Create project" asChild>
+        <Button variant="ghost" className="size-6 p-0 rounded-full">
+          <Plus className="size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <CreateProjectForm formStatus={formState} onSubmit={submit} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/projects/form.tsx
+++ b/src/components/projects/form.tsx
@@ -1,0 +1,71 @@
+import type { FormStateType } from "@/components/projects/create-new";
+import type { FC } from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { LoaderCircle } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { cn } from "@/lib/utils";
+import { z } from "zod";
+
+import {
+  FormControl,
+  FormMessage,
+  FormField,
+  FormItem,
+  Form,
+} from "@/components/ui/form";
+
+const formSchema = z.object({ title: z.string().min(1).max(30) });
+const resolver = zodResolver(formSchema);
+export type Schema = z.infer<typeof formSchema>;
+
+interface CreateProjectFormProps {
+  formStatus: FormStateType;
+  onSubmit: (data: Schema) => void;
+}
+
+export const CreateProjectForm: FC<CreateProjectFormProps> = (props) => {
+  const { formStatus, onSubmit } = props;
+  const form = useForm<Schema>({ resolver, defaultValues: { title: "" } });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4 max-w-3xl mx-auto w-full"
+      >
+        <FormField
+          name="title"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <div className="flex rounded-lg shadow-sm shadow-black/5 relative">
+                  <Input
+                    className="font-medium text-base dark:focus-within:ring-zinc-800"
+                    placeholder="Project Name"
+                    type="text"
+                    {...field}
+                  />
+                  {formStatus === "loading" && (
+                    <Button
+                      className={cn("absolute end-0 hover:bg-transparent")}
+                      variant="ghost"
+                      size="icon"
+                    >
+                      <LoaderCircle className="h-4 w-4 animate-spin" />
+                    </Button>
+                  )}
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <button type="button" className="hidden" />
+      </form>
+    </Form>
+  );
+};


### PR DESCRIPTION
### TL;DR
Added a new project creation UI component with a popover form in the sidebar navigation.

### What changed?
- Simplified the project creation mutation to only accept a project name
- Added a new "Create Project" button in the sidebar navigation header
- Created a popover form component with input validation and loading states
- Implemented toast notifications for project creation status

### How to test?
1. Navigate to the sidebar where projects are listed
2. Click the "+" button next to "Projects"
3. Enter a project name (1-30 characters)
4. Verify the loading state appears while creating
5. Confirm toast notifications appear for success/error states
6. Check that the new project appears in the projects list

### Why make this change?
To provide users with a more intuitive and accessible way to create new projects directly from the navigation sidebar, while ensuring proper validation and feedback during the creation process.