### PR TITLE
Add label creation functionality and UI components

### DIFF
--- a/convex/labels.ts
+++ b/convex/labels.ts
@@ -45,8 +45,8 @@ export const getAll = internalQuery({
 
 // LABELS MUTATIONS
 export const create = mutateWithUser({
-  args: Labels.withoutSystemFields,
-  handler: async ({ db, identity }, { name, ...rest }) => {
+  args: { name: Labels.doc.fields.name },
+  handler: async ({ db, identity }, { name }) => {
     const userId = identity.tokenIdentifier;
 
     const label = await db
@@ -57,7 +57,7 @@ export const create = mutateWithUser({
 
     if (label) throw new Error("Label already exists");
 
-    return db.insert("labels", { ...rest, userId, name });
+    return db.insert("labels", { type: "user", userId, name });
   },
 });
 

--- a/src/components/label-sidebar-menu.tsx
+++ b/src/components/label-sidebar-menu.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 
+import { CreateLabel } from "@/components/labels/create-new";
 import { LayoutGrid, ChevronRight } from "lucide-react";
 import { api } from "@/convex/_generated/api";
 import { useQuery } from "convex/react";
+import { useState } from "react";
 
 import {
   CollapsibleContent,
@@ -25,13 +27,16 @@ import {
 export const LabelSidebarMenu = () => {
   const labels = useQuery(api.labels.getAllByUser);
 
+  const [open, setOpen] = useState(true);
+
   return (
-    <Collapsible asChild defaultOpen>
+    <Collapsible asChild defaultOpen open={open} onOpenChange={setOpen}>
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip="Filters & Labels">
             <LayoutGrid />
             <span>Filters & Labels</span>
+            <CreateLabel handleEffect={() => setOpen(true)} />
             <SidebarMenuAction asChild className="data-[state=open]:rotate-90">
               <div>
                 <ChevronRight />

--- a/src/components/labels/create-new.tsx
+++ b/src/components/labels/create-new.tsx
@@ -1,0 +1,61 @@
+import { type Schema, CreateLabelForm } from "@/components/labels/form";
+import { type MouseEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { useMutation } from "convex/react";
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  PopoverTrigger,
+  PopoverContent,
+  Popover,
+} from "@/components/ui/popover";
+
+export type FormStateType = "idle" | "loading" | "success";
+
+export interface CreateLabelProps {
+  handleEffect?: () => void;
+}
+
+export function CreateLabel({ handleEffect }: CreateLabelProps) {
+  const createLabel = useMutation(api.labels.create);
+
+  const [formState, setFormState] = useState<FormStateType>("idle");
+  const [isOpen, setOpen] = useState(false);
+
+  function submit({ title }: Schema) {
+    setFormState("loading");
+
+    toast.promise(createLabel({ name: title }), {
+      success: "Label created successfully",
+      error: "Failed to create label",
+      loading: "Creating Label...",
+      finally() {
+        setOpen(false);
+        setFormState("idle");
+        handleEffect?.();
+      },
+    });
+  }
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div className="flex items-center justify-center ml-auto">
+      <Popover open={isOpen} onOpenChange={setOpen}>
+        <PopoverTrigger title="Create label" onClick={handleClick} asChild>
+          <Button variant="ghost" className="size-6 p-0 rounded-full">
+            <Plus className="size-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <CreateLabelForm formStatus={formState} onSubmit={submit} />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/labels/form.tsx
+++ b/src/components/labels/form.tsx
@@ -1,0 +1,71 @@
+import type { FormStateType } from "@/components/labels/create-new";
+import type { FC } from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { LoaderCircle } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { cn } from "@/lib/utils";
+import { z } from "zod";
+
+import {
+  FormControl,
+  FormMessage,
+  FormField,
+  FormItem,
+  Form,
+} from "@/components/ui/form";
+
+const formSchema = z.object({ title: z.string().min(1).max(30) });
+const resolver = zodResolver(formSchema);
+export type Schema = z.infer<typeof formSchema>;
+
+interface CreateLabelFormProps {
+  formStatus: FormStateType;
+  onSubmit: (data: Schema) => void;
+}
+
+export const CreateLabelForm: FC<CreateLabelFormProps> = (props) => {
+  const { formStatus, onSubmit } = props;
+  const form = useForm<Schema>({ resolver, defaultValues: { title: "" } });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4 max-w-3xl mx-auto w-full"
+      >
+        <FormField
+          name="title"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <div className="flex rounded-lg shadow-sm shadow-black/5 relative">
+                  <Input
+                    className="font-medium text-base dark:focus-within:ring-zinc-800"
+                    placeholder="Label Name"
+                    type="text"
+                    {...field}
+                  />
+                  {formStatus === "loading" && (
+                    <Button
+                      className={cn("absolute end-0 hover:bg-transparent")}
+                      variant="ghost"
+                      size="icon"
+                    >
+                      <LoaderCircle className="h-4 w-4 animate-spin" />
+                    </Button>
+                  )}
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <button type="button" className="hidden" />
+      </form>
+    </Form>
+  );
+};


### PR DESCRIPTION
### TL;DR
Added a new label creation feature with a popover form in the sidebar menu.

### What changed?
- Added a new "Create Label" button in the sidebar menu with a popover form
- Simplified the label creation mutation to only accept name parameter
- Created new components for label creation form with validation
- Implemented loading states and success/error notifications
- Added auto-expansion of the sidebar menu when creating a new label

### How to test?
1. Navigate to the sidebar menu
2. Click the "+" button next to "Filters & Labels"
3. Enter a label name in the popover form
4. Verify the label is created successfully with a toast notification
5. Confirm the new label appears in the sidebar list
6. Try creating a duplicate label to verify error handling

### Why make this change?
To provide users with a more intuitive and accessible way to create labels directly from the sidebar, improving the overall user experience and workflow efficiency.