### PR TITLE
Add todo deletion functionality and confirmation dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@clerk/elements": "^0.16.2",
     "@clerk/nextjs": "^5.7.5",
     "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.9.1(react-hook-form@7.53.1(react@18.3.1))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-aspect-ratio':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -660,6 +663,19 @@ packages:
 
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+
+  '@radix-ui/react-alert-dialog@1.1.2':
+    resolution: {integrity: sha512-eGSlLzPhKO+TErxkiGcCZGuvbVMnLA1MTnyBksGOeGRGkxHiiJUujsjmNTdWTm4iHVSRaUao9/4Ur671auMghQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.0':
     resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
@@ -3820,6 +3836,20 @@ snapshots:
       '@babel/runtime': 7.26.0
 
   '@radix-ui/primitive@1.1.0': {}
+
+  '@radix-ui/react-alert-dialog@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
 
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/src/components/todos/todo-item.tsx
+++ b/src/components/todos/todo-item.tsx
@@ -22,11 +22,12 @@ export interface TodoItemProps {
   todo: TodoItem;
   project: Project | undefined;
   label: TodoLabel | undefined;
+  handleDelete: (id: Id<"todos">) => void;
   handleToggle: (id: Id<"todos">, isCompleted: boolean) => void;
 }
 
-export function TodoItem(props: TodoItemProps) {
-  const { todo, handleToggle, project, label } = props;
+export function TodoItem({ handleToggle, handleDelete, ...props }: TodoItemProps) {
+  const { todo, project, label } = props;
   const { _id, title, isCompleted, dueDate } = todo;
 
   const priority = {
@@ -86,7 +87,7 @@ export function TodoItem(props: TodoItemProps) {
           {!isCompleted && (
             <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer duration-300 bg-slate-200/30 dark:bg-white/[.1] px-1 py-0.5 rounded-md">
               <PenLine className="size-3 text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-400 duration-300" />
-              <Trash2 className="size-3 stroke-red-300 hover:stroke-red-400 duration-300" />
+              <Trash2 className="size-3 stroke-red-300 hover:stroke-red-400 duration-300" onClick={() => handleDelete(_id)} />
             </div>
           )}
         </div>

--- a/src/components/todos/todo-list.tsx
+++ b/src/components/todos/todo-list.tsx
@@ -10,8 +10,20 @@ import { CircleCheckBig, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useMutation } from "convex/react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+
+import {
+  AlertDialogDescription,
+  AlertDialogContent,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialog,
+} from "@/components/ui/alert-dialog";
 
 export interface TodolistProps {
   todos: Todos;
@@ -20,28 +32,61 @@ export interface TodolistProps {
 }
 
 export function Todolist({ todos, projects, labels }: TodolistProps) {
-  const groups = Object.groupBy(todos ?? [], (item) =>
-    item.isCompleted ? "completed" : "inCompleted"
+  const todoGroups = Object.groupBy(todos ?? [], (todo) =>
+    todo.isCompleted ? "completed" : "inCompleted"
   );
 
-  const projectsById = Object.groupBy(projects ?? [], (item) => item._id);
-  const labelsById = Object.groupBy(labels ?? [], (item) => item._id);
+  const [deletionAlertOpen, setDeletionAlertOpen] = useState(false);
+  const [deletionAlertData, setDeletionAlertData] = useState<{ id: Id<"todos"> } | null>(null);
+
+  const projectsById = Object.groupBy(projects ?? [], (project) => project._id);
+  const labelsById = Object.groupBy(labels ?? [], (label) => label._id);
 
   const updateMutation = useMutation(api.todos.update);
+  const deleteMutation = useMutation(api.todos.remove);
 
   const toggleCompleted = (id: Id<"todos">, isCompleted: boolean) => {
-    toast.promise(updateMutation({ _id: id, isCompleted }), {
-      success: isCompleted ? "Todo completed" : "Todo reverted",
-      error: "An error occurred",
-      loading: "Updating...",
-      duration: 1000,
-    });
+    toast.promise(
+      updateMutation({ _id: id, isCompleted }),
+      {
+        success: isCompleted ? "Todo completed" : "Todo reverted",
+        error: "An error occurred",
+        loading: "Updating...",
+        duration: 1000,
+      }
+    );
+  };
+
+  const deleteTodo = (id: Id<"todos">) => {
+    setDeletionAlertData({ id });
+    setDeletionAlertOpen(true);
+  };
+
+  const closeDeletionAlert = () => {
+    setDeletionAlertOpen(false);
+    setDeletionAlertData(null);
+  };
+
+  const confirmDeletion = () => {
+    if (!deletionAlertData) return;
+
+    toast.promise(
+      deleteMutation({ todoId: deletionAlertData.id }),
+      {
+        success: "Todo deleted",
+        error: "An error occurred",
+        loading: "Deleting...",
+        duration: 1000,
+      }
+    );
+
+    closeDeletionAlert();
   };
 
   return (
     <div className="flex flex-col gap-1 py-4">
       <AnimatePresence mode="popLayout">
-        {groups.inCompleted?.map(({ projectId, labelId, ...todo }) => (
+        {todoGroups.inCompleted?.map((todo) => (
           <motion.div
             layout
             key={todo._id}
@@ -52,9 +97,10 @@ export function Todolist({ todos, projects, labels }: TodolistProps) {
           >
             <TodoItem
               todo={todo}
+              handleDelete={deleteTodo}
               handleToggle={toggleCompleted}
-              label={labelId ? labelsById[labelId]?.[0] : undefined}
-              project={projectId ? projectsById[projectId]?.[0] : undefined}
+              label={todo.labelId ? labelsById[todo.labelId]?.[0] : undefined}
+              project={todo.projectId ? projectsById[todo.projectId]?.[0] : undefined}
             />
           </motion.div>
         ))}
@@ -69,7 +115,7 @@ export function Todolist({ todos, projects, labels }: TodolistProps) {
           </Button>
         </CreateTodo>
 
-        {groups.completed?.map(({ projectId, labelId, ...todo }) => (
+        {todoGroups.completed?.map((todo) => (
           <motion.div
             layout
             key={todo._id}
@@ -80,25 +126,43 @@ export function Todolist({ todos, projects, labels }: TodolistProps) {
           >
             <TodoItem
               todo={todo}
+              handleDelete={deleteTodo}
               handleToggle={toggleCompleted}
-              label={labelId ? labelsById[labelId]?.[0] : undefined}
-              project={projectId ? projectsById[projectId]?.[0] : undefined}
+              label={todo.labelId ? labelsById[todo.labelId]?.[0] : undefined}
+              project={todo.projectId ? projectsById[todo.projectId]?.[0] : undefined}
             />
           </motion.div>
         ))}
       </AnimatePresence>
 
       <div className="flex items-center gap-1 border-b py-2 text-xs italic border-zinc-100 dark:border-zinc-800 text-foreground/60">
-        <>
-          <CircleCheckBig
-            className={cn("size-4", {
-              "text-emerald-400": groups.completed?.length,
-            })}
-          />
-          <span>+ {groups.completed?.length ?? 0}</span>
-          <span>Completed Task(s)</span>
-        </>
+        <CircleCheckBig
+          className={cn("size-4", {
+            "text-emerald-400": todoGroups.completed?.length,
+          })}
+        />
+        <span>+ {todoGroups.completed?.length ?? 0}</span>
+        <span>Completed Task(s)</span>
       </div>
+
+      <AlertDialog open={deletionAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this todo?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={closeDeletionAlert}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDeletion}>
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { buttonVariants } from "@/components/ui/button";
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};


### PR DESCRIPTION
### TL;DR
Added todo deletion functionality with confirmation dialog

### What changed?
- Added delete functionality to todo items with a trash icon
- Implemented an alert dialog component for deletion confirmation
- Added toast notifications for successful/failed deletions
- Created new alert dialog UI component using Radix UI
- Added deletion mutation handler and state management

### How to test?
1. Navigate to the todo list
2. Hover over any incomplete todo item
3. Click the trash icon
4. Verify the confirmation dialog appears
5. Test both cancel and confirm actions
6. Verify toast notifications appear appropriately
7. Confirm the todo is removed after successful deletion

### Why make this change?
To provide users with a safe way to delete todos while preventing accidental deletions through a confirmation step. The alert dialog ensures users are aware of the permanent nature of the deletion action before proceeding.