### PR TITLE
Replace Object.groupBy with lodash groupBy utility

### DIFF
--- a/src/app/dashboard/todos.tsx
+++ b/src/app/dashboard/todos.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { waitFor } from "@/lib/utils";
 import { useQueryState } from "nuqs";
+import { groupBy } from "lodash";
 
 export interface TodosProps {
   filterGroup: FilterGroups;
@@ -25,9 +26,9 @@ export const Todos = ({ filterGroup }: TodosProps) => {
   const labels = useQuery(labelsQuery, {});
   const todos = useQuery(todosQuery, {});
 
-  const projectsById = Object.groupBy(projects ?? [], (project) => project._id);
-  const labelsById = Object.groupBy(labels ?? [], (label) => label._id);
-  const todosById = Object.groupBy(todos ?? [], (todo) => todo._id);
+  const projectsById = groupBy(projects ?? [], (project) => project._id);
+  const labelsById = groupBy(labels ?? [], (label) => label._id);
+  const todosById = groupBy(todos ?? [], (todo) => todo._id);
 
   const [queryState, setQueryState] = useQueryState("tid");
   const [open, setOpen] = useState(false);

--- a/src/components/todos/todo-list.tsx
+++ b/src/components/todos/todo-list.tsx
@@ -13,6 +13,7 @@ import { api } from "@/convex/_generated/api";
 import { useMutation } from "convex/react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
+import { groupBy } from "lodash";
 import { toast } from "sonner";
 
 import {
@@ -39,7 +40,7 @@ export function Todolist(props: TodolistProps) {
   const { todos, labels, projects, onTodoItemClick, labelsById, projectsById } =
     props;
 
-  const todoGroups = Object.groupBy(todos ?? [], (todo) =>
+  const todoGroups = groupBy(todos ?? [], (todo) =>
     todo.isCompleted ? "completed" : "inCompleted"
   );
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -94,3 +94,47 @@ export function toSentenceCase(str: string): string {
     .replace(/\s+/g, " ")
     .trim();
 }
+
+/**
+ * Groups an array of objects by the value of a given key.
+ *
+ * @param collection - The array of objects to group.
+ * @param key - The key to group by.
+ * @returns An object with the values of the key as keys and an array of objects with that value as the value.
+ *
+ * @example
+ * const users = [
+ *   { name: 'John', age: 25 },
+ *   { name: 'Jane', age: 25 },
+ *   { name: 'Bob', age: 30 },
+ * ];
+ * const groupedUsers = groupBy(users, 'age');
+ * // groupedUsers is { '25': [{ name: 'John', age: 25 }, { name: 'Jane', age: 25 }], '30': [{ name: 'Bob', age: 30 }] }
+ */
+export function groupByKey<
+  T extends Record<string, unknown>,
+  K extends keyof T,
+>(collection: T[], key: K): Record<string, T[]> {
+  return collection.reduce(
+    (map, item) => {
+      const value = String(item[key]);
+      (map[value] || (map[value] = [])).push(item);
+      return map;
+    },
+    {} as Record<string, T[]>
+  );
+}
+
+export function groupBy<T, K extends keyof T | (string | number | symbol)>(
+  collection: T[],
+  cb: (item: T) => K
+): Record<string, T[]> {
+  return collection.reduce(
+    (map, item) => {
+      const value = cb(item);
+      (map[value] || (map[value] = [])).push(item);
+      return map;
+    },
+    {} as Record<K, T[]>
+  );
+}


### PR DESCRIPTION
### TL;DR
Replaced usage of `Object.groupBy` with Lodash's `groupBy` utility function and added custom grouping utility functions.

### What changed?
- Imported and implemented Lodash's `groupBy` function in place of `Object.groupBy`
- Added two new utility functions in `utils.ts`:
  - `groupByKey`: Groups objects by a specific key
  - `groupBy`: Groups items using a callback function
- Updated todos and todo-list components to use the new grouping implementation

### How to test?
1. Verify todo grouping still works in the dashboard
2. Check that todos are correctly separated between completed and incomplete
3. Confirm projects and labels are properly grouped by their IDs

### Why make this change?
`Object.groupBy` is a newer JavaScript feature with limited browser support. Using Lodash's established `groupBy` function provides better compatibility across browsers while maintaining the same functionality. The addition of custom grouping utilities also provides type-safe alternatives when Lodash isn't available.